### PR TITLE
Modding the searching of the page content

### DIFF
--- a/concordance-sample-inclusion.txt
+++ b/concordance-sample-inclusion.txt
@@ -1,0 +1,43 @@
+# Comments are ignored
+
+# Blank lines are ignored too
+# See README.md for more tips on building a concordance file.
+0 day
+0day
+abort
+black box
+black market
+black or white
+blacklisted
+child pornography
+chinese wall
+crazy
+data whitening
+dmz
+dumb
+fat-finger
+first-class citizen
+ghetto
+grandfather clause
+grandfathering
+grey box
+guys
+hang
+lame
+man in the middle
+master
+master branch
+murder board
+patient zero
+poc
+rule of thumb
+segregation
+slave
+white box
+white market
+white noise
+white team
+white cell
+whitelisted
+whitelisting
+whitepaper

--- a/pptxindex.py
+++ b/pptxindex.py
@@ -310,10 +310,17 @@ if __name__ == "__main__":
             wordlist = re.split("(?:(?:[^a-zA-Z]+')|(?:'[^a-zA-Z]+))|(?:[^a-zA-Z']+)", page)
             cswordlist = re.split("(?:(?:[^a-zA-Z]+')|(?:'[^a-zA-Z]+))|(?:[^a-zA-Z']+)", cspage)
 
-            # Process the concordance file entry.  If it is None, then use 
+            # Process the concordance file entry.  If it is None, then use
             # the key as the search string
             if concordance[key] == None:
-                if (key.lower() in page):
+                if len(key.split()) == 1:
+                    # The page.split() below cuts up the string page variable into a list
+                    # which makes it more accurate in finding a single word
+                    if (key.lower() in page.split()):
+                        pages.append(bookpagenum)
+                else:
+                    # Here we search the page string (not list) for multi-word keys
+                    if key.lower() in page:
                         pages.append(bookpagenum)
             # Else, evaluate the right-side of the concordance entry as a Python expression
             elif eval(concordance[key]):


### PR DESCRIPTION
- If the key from concordance file is a single word, then we convert `page` from a string to a list for more accurate word matching (since it will not match words within words).
- If the key is multiple words, then we do the normal match against the `page` in string form
- Sorry about the errant space at the end of line 313